### PR TITLE
Use customized loggers

### DIFF
--- a/argussight/core/video_processes/savers/stream_buffer.py
+++ b/argussight/core/video_processes/savers/stream_buffer.py
@@ -1,12 +1,15 @@
 from collections import deque
+from logging import Logger
 from typing import Any, Dict
 
 from argussight.core.video_processes.savers.video_saver import VideoSaver
 
 
 class StreamBuffer(VideoSaver):
-    def __init__(self, collector_config, exposed_parameters: Dict[str, Any]) -> None:
-        super().__init__(collector_config, exposed_parameters)
+    def __init__(
+        self, collector_config, exposed_parameters: Dict[str, Any], logger: Logger
+    ) -> None:
+        super().__init__(collector_config, exposed_parameters, logger)
         self._queue = deque(maxlen=self._parameters["max_queue_len"])
 
     @classmethod

--- a/argussight/core/video_processes/savers/video_saver.py
+++ b/argussight/core/video_processes/savers/video_saver.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import os
 from datetime import datetime
 from enum import Enum
+from logging import Logger
 from multiprocessing import Queue
 from typing import Any, Dict, Iterable, Tuple
 
@@ -20,8 +21,10 @@ class SaveFormat(Enum):
 
 
 class VideoSaver(Vprocess):
-    def __init__(self, collector_config, exposed_parameters: Dict[str, Any]) -> None:
-        super().__init__(collector_config, exposed_parameters)
+    def __init__(
+        self, collector_config, exposed_parameters: Dict[str, Any], logger: Logger
+    ) -> None:
+        super().__init__(collector_config, exposed_parameters, logger)
         self._command_timeout = 0.04
         self._recording_start_time = None
 
@@ -114,9 +117,9 @@ class VideoSaver(Vprocess):
         if self._current_frame_number != -1:
             self._missed_frames += current_frame_number - self._current_frame_number - 1
             if current_frame_number > self._current_frame_number + 1:
-                print(f"Frames Missed in Total: {self._missed_frames}")
+                self._logger.warning(f"Frames Missed in Total: {self._missed_frames}")
         else:
-            print(f"Started reading at frame {current_frame_number}")
+            self._logger.info(f"Started reading at frame {current_frame_number}")
         self._current_frame_number = current_frame_number
 
         if self._parameters["recording"]:

--- a/argussight/core/video_processes/streamer/flow_detection.py
+++ b/argussight/core/video_processes/streamer/flow_detection.py
@@ -1,5 +1,6 @@
 from collections import deque
 from datetime import datetime
+from logging import Logger
 from typing import Any, Dict, Tuple
 
 import cv2
@@ -31,9 +32,13 @@ class Point:
 
 class FlowDetection(Streamer):
     def __init__(
-        self, collector_config, free_port, exposed_parameters: Dict[str, Any]
+        self,
+        collector_config,
+        free_port,
+        exposed_parameters: Dict[str, Any],
+        logger: Logger,
     ) -> None:
-        super().__init__(collector_config, free_port, exposed_parameters)
+        super().__init__(collector_config, free_port, exposed_parameters, logger)
         self._previous_frame = None
         self._min_distance = 50
         self._p0 = []

--- a/argussight/core/video_processes/streamer/optical_flow_detection.py
+++ b/argussight/core/video_processes/streamer/optical_flow_detection.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from logging import Logger
 from typing import Any, Dict
 
 import cv2
@@ -9,9 +10,13 @@ from argussight.core.video_processes.streamer.streamer import Streamer
 
 class OpticalFlowDetection(Streamer):
     def __init__(
-        self, collector_config, free_port, exposed_parameters: Dict[str, Any]
+        self,
+        collector_config,
+        free_port,
+        exposed_parameters: Dict[str, Any],
+        logger: Logger,
     ) -> None:
-        super().__init__(collector_config, free_port, exposed_parameters)
+        super().__init__(collector_config, free_port, exposed_parameters, logger)
         self._previous_frame = None
         self._speeds = []
         self._current_speed = 0

--- a/argussight/core/video_processes/streamer/streamer.py
+++ b/argussight/core/video_processes/streamer/streamer.py
@@ -3,6 +3,7 @@ import json
 import queue
 import subprocess
 import uuid
+from logging import Logger
 from multiprocessing import Queue
 from typing import Any, Dict
 
@@ -14,9 +15,13 @@ from argussight.core.video_processes.vprocess import FrameFormat, Vprocess
 
 class Streamer(Vprocess):
     def __init__(
-        self, collector_config, free_port, exposed_parameters: Dict[str, Any]
+        self,
+        collector_config,
+        free_port,
+        exposed_parameters: Dict[str, Any],
+        logger: Logger,
     ) -> None:
-        super().__init__(collector_config, exposed_parameters)
+        super().__init__(collector_config, exposed_parameters, logger)
 
         self._processed_frame = None  # this should be changed in process_frame
         self._frame_format = (
@@ -48,7 +53,8 @@ class Streamer(Vprocess):
                     self.process_frame()
                     self.stream()
         except redis.exceptions.ConnectionError as e:
-            print(f"Connection error {e} by {type(self)}")
+            self._logger.error("Connection error")
+            self._logger.exception(e)
 
     def stream(self) -> None:
         if self._processed_frame is not None:

--- a/argussight/grpc/server.py
+++ b/argussight/grpc/server.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from concurrent import futures
 
@@ -104,7 +105,7 @@ def serve(collector_config):
     )
     server.add_insecure_port("[::]:50051")
     server.start()
-    print("Server started on port 50051")
+    logging.getLogger("GRPC Server").info("Server started on port 50051")
     try:
         while True:
             time.sleep(86400)  # Keep server running

--- a/argussight/logger.py
+++ b/argussight/logger.py
@@ -1,0 +1,68 @@
+import logging
+import os
+
+import colorlog
+
+LOG_FORMAT_SHARED = "%(asctime)s - [%(type)s] - %(name)s - %(levelname)s - %(message)s"
+LOG_FORMAT_SPECIFIC = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+LOG_DIR = "logs"
+LOG_FILE = os.path.join(LOG_DIR, "Shared_logs.log")
+
+
+def snake_to_camel(snake_str: str) -> str:
+    components = snake_str.split("_")
+    return "".join(x.capitalize() for x in components)
+
+
+class TypeFilter(logging.Filter):
+    def __init__(self, log_type: str):
+        self.log_type = log_type
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.type = self.log_type
+        return True
+
+
+def configure_logger(name: str, type: str) -> logging.Logger:
+    """Configures/Creates a single logger."""
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+
+    if logger.hasHandlers():
+        return logger
+
+    os.makedirs(LOG_DIR, exist_ok=True)
+
+    # File handlers
+    camel_type = snake_to_camel(type)
+    type_filter = TypeFilter(camel_type)
+
+    shared_file_handler = logging.FileHandler(LOG_FILE)
+    shared_file_handler.setFormatter(logging.Formatter(LOG_FORMAT_SHARED))
+    shared_file_handler.addFilter(type_filter)
+
+    specific_log_file = os.path.join(LOG_DIR, f"{camel_type}.log")
+    type_file_handler = logging.FileHandler(specific_log_file)
+    type_file_handler.setFormatter(logging.Formatter(LOG_FORMAT_SPECIFIC))
+
+    # Console handler
+    console_handler = colorlog.StreamHandler()
+    colored_formatter = colorlog.ColoredFormatter(
+        f"%(log_color)s{LOG_FORMAT_SHARED}",
+        log_colors={
+            "DEBUG": "cyan",
+            "INFO": "blue",
+            "WARNING": "orange",
+            "ERROR": "red",
+            "CRITICAL": "magenta",
+        },
+    )
+    console_handler.setFormatter(colored_formatter)
+    console_handler.addFilter(type_filter)
+
+    # Attach handlers
+    logger.addHandler(shared_file_handler)
+    logger.addHandler(type_file_handler)
+    logger.addHandler(console_handler)
+
+    return logger

--- a/poetry.lock
+++ b/poetry.lock
@@ -204,6 +204,23 @@ files = [
 ]
 
 [[package]]
+name = "colorlog"
+version = "6.9.0"
+description = "Add colours to the output of Python's logging module."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "colorlog-6.9.0-py3-none-any.whl", hash = "sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff"},
+    {file = "colorlog-6.9.0.tar.gz", hash = "sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+development = ["black", "flake8", "mypy", "pytest", "types-colorama"]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 description = "Distribution utilities"
@@ -1864,4 +1881,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "2004ac59fea1b803589e9620765b27b9c9e98ec537f8f4d38995af6fb5257152"
+content-hash = "2dd0b96c5f74ae7e54296382b7a73736e200db9550eb80114a04ee2fd3acb4ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ Flask = "^3.0.3"
 requests = "^2.32.3"
 websocket-client = "^1.8.0"
 mxcube-video-streamer = ">=1.7.0"
+colorlog = "^6.9.0"
 
 [tool.poetry.scripts]
 argussight = "argussight.main:run"


### PR DESCRIPTION
This PR adds different loggers for every process including `Spawner` and `StreamsProxy`. 
Loggers are all using the same style configuration and should be created by using the new `configure_logger` function (`Spawner` creates the loggers for every process).

Regarding the log files: upon running a logs folder is created. Every log entry can be found within the `shared_logs.log` file and the log file specific to the process class. Every entry always contains the name of the process that created the entry, in the shared file, the process class is also added