### PR TITLE
Update logger colors

### DIFF
--- a/argussight/logger.py
+++ b/argussight/logger.py
@@ -52,7 +52,7 @@ def configure_logger(name: str, type: str) -> logging.Logger:
         log_colors={
             "DEBUG": "cyan",
             "INFO": "blue",
-            "WARNING": "orange",
+            "WARNING": "yellow",
             "ERROR": "red",
             "CRITICAL": "magenta",
         },


### PR DESCRIPTION
This PR updates the color scheme of the logger changing the warning color from `orange` (which is not a predefined color) to `yellow`