### PR TITLE
remove the fixed python version for the pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,5 @@
 ---
 
-default_language_version:
-  # This should be set to the lowest Python version that we support.
-  python: python3.10
-
 repos:
 
   - repo: https://github.com/adrienverge/yamllint


### PR DESCRIPTION
This PR removes the fixed python version to be `3.10`, for the pre-commit, making it easier to check if another version is used locally