### PR TITLE
refactor server.py and introduce graceful shutdown

### DIFF
--- a/argussight/core/spawner.py
+++ b/argussight/core/spawner.py
@@ -170,7 +170,7 @@ class Spawner:
                 return process
         return None
 
-    def terminate_processes(self, names: List[str]) -> None:
+    def terminate_processes(self, names: List[str], ignore_restrictions=False) -> None:
         for name in names:
             self.check_for_running_process(name)
             worker_type = self._processes[name]["type"]
@@ -206,9 +206,16 @@ class Spawner:
             if (
                 worker_type in self._restricted_classes
                 and self.check_restricted_access(worker_type)
+                and not ignore_restrictions
             ):
                 process = self.find_process_in_config_by_name(name)
                 self.start_process(process["name"], process["type"])
+
+    def terminate_all_processes(self) -> None:
+        self.terminate_processes(list(self._processes.keys()), ignore_restrictions=True)
+        self._settings_manager.shutdown()
+        self._settings_manager.join()
+        self._logger.info("terminated all processes")
 
     def wait_for_manager(
         self,

--- a/argussight/grpc/server.py
+++ b/argussight/grpc/server.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from concurrent import futures
+from threading import Event
 
 import grpc
 
@@ -9,37 +10,108 @@ import argussight.grpc.argus_service_pb2_grpc as pb2_grpc
 from argussight.core.spawner import ProcessError, Spawner
 from argussight.grpc.helper_functions import pack_to_any, unpack_from_any
 
+logger = logging.getLogger("GRPC Server")
+
+
+def check_shutdown_event(func):
+    """
+    Decorator to check if the shutdown event is set before processing the request.
+    If the shutdown event is set, it aborts the request with a GRPC UNAVAILABLE status.
+    """
+
+    def wrapper(self, request, context, *args, **kwargs):
+        if self.shutdown_event.is_set():
+            context.abort(grpc.StatusCode.UNAVAILABLE, "Server is shutting down.")
+        return func(self, request, context, *args, **kwargs)
+
+    return wrapper
+
 
 class SpawnerService(pb2_grpc.SpawnerServiceServicer):
-    def __init__(self, collector_config):
+    """
+    gRPC service for managing processes.
+    """
+
+    def __init__(self, collector_config, shutdown_event: Event):
+        """
+        Intializes the SpawnerService
+
+        Args:
+            collector_config: Configuration for the collector.
+            shutdown_event: Event to signal server shutdown.
+        """
         self.spawner = Spawner(collector_config)
         self._min_waiting_time = 1
+        self.shutdown_event = shutdown_event
 
+    @check_shutdown_event
     def StartProcesses(self, request, context):
+        """
+        Starts a process based on the provided request.
+
+        Args:
+            request (pb2.StartProcessesRequest): gRPC request containing process details.
+            context: gRPC context object.
+
+        Returns:
+            pb2.StartProcessesResponse: gRPC response indicating success or failure.
+        """
         try:
             self.spawner.start_process(request.name, request.type)
             return pb2.StartProcessesResponse(status="success")
         except ProcessError as e:
-            return pb2.StartProcessesResponse(status="failure", error_message=str(e))
-        except Exception as e:
+            logger.error(f"Error starting process {request.name}: {str(e)}")
             return pb2.StartProcessesResponse(
-                status="failure", error_message=f"Unexpected error: {str(e)}"
+                status="failure", error_message="Failed to start process"
+            )
+        except Exception as e:
+            logger.exception(
+                f"Unexpected error starting process {request.name}: {str(e)}"
+            )
+            return pb2.StartProcessesResponse(
+                status="failure", error_message="An unexpected error occured"
             )
 
+    @check_shutdown_event
     def TerminateProcesses(self, request, context):
+        """
+        Terminates one or more processes based on the provided request.
+
+        Args:
+            request (pb2.TerminateProcessesRequest): gRPC request containing process names.
+            context: gRPC context object.
+
+        Returns:
+            pb2.TerminateProcessesResponse: gRPC response indicating success or failure.
+        """
         try:
             self.spawner.terminate_processes(request.names)
             return pb2.TerminateProcessesResponse(status="success")
         except ProcessError as e:
+            logger.error(f"Error terminating processes {request.names}: {str(e)}")
             return pb2.TerminateProcessesResponse(
-                status="failure", error_message=str(e)
+                status="failure", error_message="Failed to terminate processes"
             )
         except Exception as e:
+            logger.exception(
+                f"Unexpected error terminating processes {request.names}: {str(e)}"
+            )
             return pb2.TerminateProcessesResponse(
-                status="failure", error_message=f"Unexpected error: {str(e)}"
+                status="failure", error_message="An unexpected error occured"
             )
 
+    @check_shutdown_event
     def ManageProcesses(self, request, context):
+        """
+        Manages a process based on the provided request.
+
+        Args:
+            request (pb2.ManageProcessesRequest): gRPC request containing process command details.
+            context: gRPC context object.
+
+        Returns:
+            pb2.ManageProcessesResponse: gRPC response indicating success or failure.
+        """
         try:
             self.spawner.manage_process(
                 request.name,
@@ -48,13 +120,30 @@ class SpawnerService(pb2_grpc.SpawnerServiceServicer):
             )
             return pb2.ManageProcessesResponse(status="success")
         except ProcessError as e:
-            return pb2.ManageProcessesResponse(status="failure", error_message=str(e))
-        except Exception as e:
+            logger.error(f"Error managing process {request.name}: {str(e)}")
             return pb2.ManageProcessesResponse(
-                status="failure", error_message=f"Unexpected error: {str(e)}"
+                status="failure", error_message="Unable to manage process"
+            )
+        except Exception as e:
+            logger.exception(
+                f"Unexpected error managing process {request.name}: {str(e)}"
+            )
+            return pb2.ManageProcessesResponse(
+                status="failure", error_message="An unexpected error occured"
             )
 
+    @check_shutdown_event
     def GetProcesses(self, request, context):
+        """
+        Retrieves the currently running processes and available process types.
+
+        Args:
+            request (pb2.GetProcessesRequest): Empty gRPC request.
+            context: gRPC context object.
+
+        Returns:
+            pb2.GetProcessesResponse: gRPC response containing running processes and available types.
+        """
         try:
             running_processes, available_types, streams = self.spawner.get_processes()
             running_dict = {}
@@ -74,11 +163,23 @@ class SpawnerService(pb2_grpc.SpawnerServiceServicer):
                 streams=streams,
             )
         except Exception as e:
+            logger.exception(f"Unexpected error retrieving processes: {str(e)}")
             return pb2.GetProcessesResponse(
-                status="failure", error_message=f"Unexpected error: {str(e)}"
+                status="failure", error_message="Could not retrieve processes"
             )
 
+    @check_shutdown_event
     def ChangeSettings(self, request, context):
+        """
+        Changes the settings of a process based on the provided request.
+
+        Args:
+            request (pb2.ChangeSettingsRequest): gRPC request containing process settings.
+            context: gRPC context object.
+
+        Returns:
+            pb2.ChangeSettingsResponse: gRPC response indicating success or failure.
+        """
         try:
             settings = {}
             for key, any_object in request.settings.items():
@@ -86,28 +187,69 @@ class SpawnerService(pb2_grpc.SpawnerServiceServicer):
             self.spawner.manage_process(request.name, "settings", [settings])
             return pb2.ChangeSettingsResponse(status="success")
         except ProcessError as e:
-            return pb2.ChangeSettingsResponse(status="failure", error_message=str(e))
+            logger.error(f"Error changing settings {request.name}: {str(e)}")
+            return pb2.ChangeSettingsResponse(
+                status="failure", error_message="Could not change settings"
+            )
         except Exception as e:
-            return pb2.ChangeSettingsResponse(status="failure", error_message=str(e))
+            logger.exception(
+                f"Unexpected error while changing settings of {request.name}: {str(e)}"
+            )
+            return pb2.ChangeSettingsResponse(
+                status="failure", error_message="An unexpected error occured"
+            )
 
+    @check_shutdown_event
     def AddStream(self, request, context):
+        """
+        Adds a stream to a process based on the provided request.
+
+        Args:
+            request (pb2.AddStreamRequest): gRPC request containing stream details.
+            context: gRPC context object.
+
+        Returns:
+            pb2.AddStreamResponse: gRPC response indicating success or failure.
+        """
         try:
             self.spawner.add_stream(request.name, request.port, request.stream_id)
             return pb2.AddStreamResponse(status="success")
         except Exception as e:
-            return pb2.AddStreamResponse(status="failure", error_message=str(e))
+            logger.exception(f"Unexpected error while adding stream: {str(e)}")
+            return pb2.AddStreamResponse(
+                status="failure", error_message=f"Couldn't add stream {request.name}"
+            )
 
 
 def serve(collector_config):
+    """
+    Starts the gRPC server and listens for incoming requests.
+
+    Args:
+        collector_config: Configuration for the collector.
+    """
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    pb2_grpc.add_SpawnerServiceServicer_to_server(
-        SpawnerService(collector_config), server
-    )
+    shutdown_event = Event()
+    spawner_service = SpawnerService(collector_config, shutdown_event)
+    pb2_grpc.add_SpawnerServiceServicer_to_server(spawner_service, server)
     server.add_insecure_port("[::]:50051")
     server.start()
-    logging.getLogger("GRPC Server").info("Server started on port 50051")
+    logger.info("Server started on port 50051")
     try:
         while True:
-            time.sleep(86400)  # Keep server running
+            time.sleep(86400)
     except KeyboardInterrupt:
-        server.stop(0)
+        logger.info("Server shutting down...")
+
+        shutdown_event.set()  # Mark shutdown to prevent new requests
+
+        server.stop(grace=5)  # Allow server to finish processing current requests
+
+        # Terminate all running processes
+        try:
+            spawner_service.spawner.terminate_all_processes()
+            logger.info("All processes terminated successfully.")
+        except Exception as e:
+            logger.error(f"Error terminating processes: {str(e)}")
+
+        logger.info("Server stopped.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -560,14 +560,14 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev"]
 files = [
-    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
-    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
+    {file = "jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67"},
+    {file = "jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d"},
 ]
 
 [package.dependencies]
@@ -854,26 +854,27 @@ test = ["mkdocs-d2-plugin", "mkdocs-include-markdown-plugin", "mkdocs-macros-tes
 
 [[package]]
 name = "mxcube-video-streamer"
-version = "1.7.0"
+version = "1.8.2"
 description = "FastAPI Based video streamer"
 optional = false
-python-versions = "<3.12,>=3.8"
+python-versions = "<3.12,>=3.10"
 groups = ["main"]
 files = [
-    {file = "mxcube_video_streamer-1.7.0-py3-none-any.whl", hash = "sha256:281d629a3e7171c6ae6045f4ed269e8ab0e2003b50bafc35bdcec761087e8aa2"},
-    {file = "mxcube_video_streamer-1.7.0.tar.gz", hash = "sha256:272d0dc033f7b2d9977baa4b7ac2236a4cf208f2324fcbe5832f05cdc140bb35"},
+    {file = "mxcube_video_streamer-1.8.2-py3-none-any.whl", hash = "sha256:356998627e4ecc74b6b764dcd4799be0d85e4d658f10810b877d9af14ac57178"},
+    {file = "mxcube_video_streamer-1.8.2.tar.gz", hash = "sha256:0de041c5f17148cec4668a7683f39f1064cd5036d6de311de23a29965466bba6"},
 ]
 
 [package.dependencies]
 fastapi = ">=0.115.6,<0.116.0"
-jinja2 = ">=3.1.5,<4.0.0"
+jinja2 = ">=3.1.6,<4.0.0"
+numpy = ">=1.26.0,<2.0"
 opencv-python = ">=4.10.0.84,<5.0.0.0"
 pillow = ">=10.4.0,<11.0.0"
 pydantic = ">=2.8.2,<2.9.0"
 pydantic-settings = ">=2.4.0"
 pytango = ">=9.3.6,<10.0.0"
 redis = ">=4.3.5,<5.0.0"
-uvicorn = ">=0.30.6,<0.31.0"
+uvicorn = ">=0.34.0,<0.35.0"
 websockets = ">=12.0,<13.0"
 
 [[package]]
@@ -1751,14 +1752,14 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.30.6"
+version = "0.34.0"
 description = "The lightning-fast ASGI server."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "uvicorn-0.30.6-py3-none-any.whl", hash = "sha256:65fd46fe3fda5bdc1b03b94eb634923ff18cd35b2f084813ea79d1f103f711b5"},
-    {file = "uvicorn-0.30.6.tar.gz", hash = "sha256:4b15decdda1e72be08209e860a1e10e92439ad5b97cf44cc945fcbee66fc5788"},
+    {file = "uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4"},
+    {file = "uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9"},
 ]
 
 [package.dependencies]
@@ -1767,7 +1768,7 @@ h11 = ">=0.8"
 typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
-standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+standard = ["colorama (>=0.4)", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [[package]]
 name = "virtualenv"
@@ -1953,4 +1954,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "2cdc11ebb924531abf60be9e336599bc4be09eff1c9840910d1d6ad891ad3b4a"
+content-hash = "70fd4cc52e2b25a64d693f85648641ae3ffb00d9345a4de9820fb599dd83ef27"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ python-levenshtein = "^0.25.1"
 Flask = "^3.0.3"
 requests = "^2.32.3"
 websocket-client = "^1.8.0"
-mxcube-video-streamer = ">=1.7.0"
+mxcube-video-streamer = ">=1.8.2"
 colorlog = "^6.9.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
This PR refactors server.py (adding docstrings,  imporve loggings), and introduces a graceful server shutdown.

On Shutdown, all processes are gracefully terminated (we update to video-streamer 1.8.2, so that it is possible for the streams as well) through the new `terminate_all_processes` function call. A shutdown event_flag and wrapper are also added, to make sure that no process can be spawned or modified, while the server is shutting down