### PR TITLE
remove add and remove stream api's from stream proxy

### DIFF
--- a/argussight/core/spawner.py
+++ b/argussight/core/spawner.py
@@ -8,7 +8,6 @@ from logging import Logger
 from typing import Any, Dict, List, Tuple
 
 import psutil
-import requests
 import yaml
 
 import argussight.streamsproxy as StreamsProxy
@@ -34,13 +33,39 @@ class Spawner:
         current_dir = os.path.dirname(os.path.abspath(__file__))
         self.load_config(os.path.join(current_dir, "configurations/config.yaml"))
 
+        self._starts_stream_proxy()
+
+    def cleanup(self):
+        try:
+            self._logger.info("Terminating all processes...")
+            self.terminate_all_processes()
+            self._logger.info("All processes terminated successfully.")
+        except Exception as e:
+            self._logger.error(f"Error terminating processes: {str(e)}")
+
+        self._logger.info("Terminating streams layer process...")
+        self._proxy_command_queue.put({"action": "shutdown_server"})
+        self.streams_layer_process.join(timeout=10)
+
+        if self.streams_layer_process.is_alive():
+            self._logger.warning(
+                "Streams layer process did not shut down gracefully, terminating forcefully..."
+            )
+            self.streams_layer_process.terminate()
+            self.streams_layer_process.join(timeout=10)
+
+    def _starts_stream_proxy(self):
+        self._proxy_command_queue = multiprocessing.Queue()
+        self.streams_layer_process = multiprocessing.Process(
+            target=StreamsProxy.run,
+            args=(self._proxy_command_queue, self.config["streams_layer_port"]),
+        )
+
+        self.streams_layer_process.start()
+
         self._logger.info(
             f"running stream_layer on port {self.config['streams_layer_port']}"
         )
-        streams_layer_process = multiprocessing.Process(
-            target=StreamsProxy.run, args=(self.config["streams_layer_port"],)
-        )
-        streams_layer_process.start()
 
     def load_config(self, path_config_file: str) -> None:
         with open(path_config_file, "r") as f:
@@ -118,15 +143,17 @@ class Spawner:
         return False
 
     def add_stream(self, name, port, stream_id) -> None:
-        requests.post(
-            f"http://localhost:{str(self.config['streams_layer_port'])}/add-stream",
-            params={
-                "path": name,
-                "port": port,
-                "id": stream_id,
-            },
+        self._proxy_command_queue.put(
+            {"action": "add_stream", "path": name, "port": port, "id": stream_id}
         )
         self._streams.add(name)
+
+    def remove_stream(self, name) -> None:
+        self._proxy_command_queue.put({"action": "remove_stream", "path": name})
+        self._streams.discard(name)
+
+    def close_all_streams(self) -> None:
+        self._proxy_command_queue.put({"action": "shutdown_streams"})
 
     def start_process(self, name: str, type: str) -> None:
         if name in self._processes:
@@ -196,11 +223,7 @@ class Spawner:
             del self._processes[name]
 
             if worker_type in self._streamer_types:
-                requests.post(
-                    f"http://localhost:{str(self.config['streams_layer_port'])}/remove-stream",
-                    params={"path": name},
-                )
-                self._streams.discard(name)
+                self.remove_stream(name)
 
             self._logger.info(f"terminated {name} of type {worker_type}")
             if (

--- a/argussight/grpc/server.py
+++ b/argussight/grpc/server.py
@@ -250,13 +250,12 @@ def serve(collector_config):
     finally:
         logger.info("Server shutting down...")
 
-        server.stop(grace=5)  # Allow server to finish processing current requests
+        server.stop(grace=10)  # Allow server to finish processing current requests
 
-        # Terminate all running processes
         try:
-            spawner_service.spawner.terminate_all_processes()
-            logger.info("All processes terminated successfully.")
+            spawner_service.spawner.cleanup()
+            logger.info("Spawner cleanup completed successfully.")
         except Exception as e:
-            logger.error(f"Error terminating processes: {str(e)}")
+            logger.error(f"Error during spawner cleanup: {str(e)}")
 
         logger.info("Server stopped.")

--- a/argussight/streamsproxy.py
+++ b/argussight/streamsproxy.py
@@ -1,7 +1,11 @@
 import asyncio
+import contextlib
+import multiprocessing
+import queue
 import signal
 from typing import Dict
 
+import uvicorn
 import websockets
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
@@ -13,23 +17,9 @@ active_streams: Dict[str, Dict[str, any]] = {}
 client_queues: Dict[WebSocket, asyncio.Queue] = {}
 
 logger = configure_logger("StreamsProxy", "streams_proxy")
+shutdown_event = asyncio.Event()
 
 
-async def shutdown(loop, signal=None):
-    logger.info(
-        f"Received exit signal {signal.name if signal else 'unknown'}, shutting down..."
-    )
-    for path, info in active_streams.items():
-        task = info.get("task")
-        if task:
-            task.cancel()
-    await asyncio.gather(
-        *(t["task"] for t in active_streams.values()), return_exceptions=True
-    )
-    loop.stop()
-
-
-@app.post("/add-stream")
 async def add_stream(path: str, port: int, id: str) -> Dict[str, str]:
     if path in active_streams:
         return {"message": f"Stream already exists at path /{path}"}
@@ -39,25 +29,69 @@ async def add_stream(path: str, port: int, id: str) -> Dict[str, str]:
     active_streams[path] = {"url": original_ws_url, "clients": set()}
 
     # Spawn the upstream worker
-    loop = asyncio.get_running_loop()
-    for s in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(s, lambda s=s: asyncio.create_task(shutdown(loop, s)))
-    task = loop.create_task(upstream_worker(path, original_ws_url))
+    task = asyncio.create_task(upstream_worker(path, original_ws_url))
     active_streams[path]["task"] = task
 
     logger.info(f"Stream added at path /{path}")
     return {"message": f"Stream added at path /{path}"}
 
 
-@app.post("/remove-stream")
 async def remove_stream(path: str) -> Dict[str, str]:
-    if path not in active_streams:
-        return {"message": "Stream not found"}
+    stream = active_streams.pop(path, None)
 
-    del active_streams[path]
-    logger.info(f"Stream removed at path /{path}")
+    if stream is None:
+        return {"message": f"No stream exists at path /{path}"}
+
+    task = stream.get("task", None)
+    logger.info(
+        f"Removing stream at path /{path} with {len(stream.get('clients', []))} active clients"
+    )
+
+    # First disconnect clients
+    clients = stream.get("clients", set())
+    for client in clients:
+        client_queues.pop(client, None)
+        await client.close(code=1000, reason="Stream removed by server")
+
+    if task:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
     return {"message": f"Stream removed at path /{path}"}
+
+
+async def command_consumer(command_queue: multiprocessing.Queue):
+    while True:
+        try:
+            # Use asyncio.to_thread to call the blocking get method of the multiprocessing.Queue
+            # We use a timeout to periodically check for cancellation and avoid blocking indefinitely
+            command = await asyncio.to_thread(command_queue.get, timeout=1)
+        except queue.Empty:
+            if shutdown_event.is_set():
+                logger.info("Server shutdown initiated, stopping command consumer...")
+                break
+            continue
+
+        if not command["action"]:
+            logger.warning("Received command without action")
+            continue
+
+        if command["action"] == "add_stream":
+            await add_stream(command["path"], command["port"], command["id"])
+        elif command["action"] == "remove_stream":
+            await remove_stream(command["path"])
+        elif command["action"] == "shutdown_streams":
+            await shutdown_streams()
+        elif command["action"] == "shutdown_server":
+            logger.info(
+                "Received shutdown command from spawner, initiating server shutdown..."
+            )
+            shutdown_event.set()
+            await shutdown_streams()
+            return
+        else:
+            logger.warning(f"Unknown command action: {command['action']}")
 
 
 async def upstream_worker(path: str, url: str):
@@ -67,7 +101,11 @@ async def upstream_worker(path: str, url: str):
         try:
             async with websockets.connect(url) as original_ws:
                 logger.info(f"Connected upstream {url} for {path}")
-
+                if shutdown_event.is_set():
+                    logger.info(
+                        f"Server shutdown initiated, stopping upstream worker for {path}..."
+                    )
+                    break
                 async for data in original_ws:
                     clients = active_streams[path]["clients"].copy()
                     for client in clients:
@@ -78,23 +116,27 @@ async def upstream_worker(path: str, url: str):
                                 reconnection_tries = 0  # Reset on successful send
                             except asyncio.QueueFull:
                                 logger.warning("Dropping frame for slow client")
-
+        except asyncio.CancelledError:
+            logger.info(f"Upstream worker for {path} cancelled")
+            break
         except Exception as e:
+            if shutdown_event.is_set():
+                logger.info(
+                    f"Server shutdown initiated, stopping upstream worker for {path}..."
+                )
+                break
             logger.error(f"Upstream worker for {path} failed: {e}")
             if reconnection_tries >= 3:
                 logger.error(
                     f"Max reconnection attempts reached for {path}, shutting down."
                 )
+                logger.info(f"Removing stream at path /{path} due to upstream failure")
+                await remove_stream(path)
                 break
             reconnection_tries += 1
             logger.info(f"Reconnecting upstream for {path} in 2 seconds...")
             await asyncio.sleep(2)
             logger.info(f"Reconnecting upstream for {path}")
-
-    logger.info(f"Upstream for {path} closed")
-    for client in active_streams.get(path, {}).get("clients", []):
-        await client.close()
-    active_streams.pop(path, None)
 
 
 @app.websocket("/ws/{path}")
@@ -113,11 +155,19 @@ async def websocket_proxy(websocket: WebSocket, path: str):
 
     try:
         while True:
-            data = await q.get()
-            if isinstance(data, str):
-                await websocket.send_text(data)
-            else:
-                await websocket.send_bytes(data)
+            try:
+                data = await asyncio.wait_for(q.get(), timeout=1.0)
+                if isinstance(data, str):
+                    await websocket.send_text(data)
+                else:
+                    await websocket.send_bytes(data)
+            except asyncio.TimeoutError:
+                if shutdown_event.is_set():
+                    logger.info(
+                        "Server shutdown initiated, closing client connection..."
+                    )
+                    break
+                continue
 
     except WebSocketDisconnect:
         logger.info("Client disconnected")
@@ -127,10 +177,51 @@ async def websocket_proxy(websocket: WebSocket, path: str):
         await websocket.close()
 
 
-def run(port: int = 7000) -> None:
-    import uvicorn
+async def shutdown_streams() -> Dict[str, str]:
+    paths = list(active_streams.keys())
+    try:
+        logger.info(f"Shutting down all streams: {paths}")
+        for path in paths:
+            await remove_stream(path)
+    except Exception as e:
+        logger.error(f"Error shutting down streams: {str(e)}")
+        return {"message": "Error shutting down streams"}
+    return {"message": "All streams shutdown"}
 
-    uvicorn.run(app, host="0.0.0.0", port=port)
+
+def run(command_queue: multiprocessing.Queue, port: int = 7000) -> None:
+    async def run_server(stop_event: asyncio.Event):
+        config = uvicorn.Config(app, host="0.0.0.0", port=port)
+        server = uvicorn.Server(config)
+
+        @app.on_event("startup")
+        async def startup():
+            app.state.command_task = asyncio.create_task(
+                command_consumer(command_queue)
+            )
+
+        async def stop_when_event_is_set():
+            await stop_event.wait()
+            server.should_exit = True
+
+        watcher_task = asyncio.create_task(stop_when_event_is_set())
+
+        try:
+            await server.serve()
+        finally:
+            watcher_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await watcher_task
+
+    async def main():
+        loop = asyncio.get_running_loop()
+
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, shutdown_event.set)
+
+        await run_server(shutdown_event)
+
+    asyncio.run(main())
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -1890,14 +1890,14 @@ ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"},
-    {file = "requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517"},
+    {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
+    {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
 ]
 
 [package.dependencies]
@@ -2562,4 +2562,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "3d42d88e80abf93461054886551a9cd6b1a5409cf77fb49f0e17dbb51fae52e6"
+content-hash = "15d96fcb3baa11b134599b08b6a84b41d6cb467f9e0122beeb6e92f3656897cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ pydantic = ">=2.8.2,<2.9.0"
 python-levenshtein = "^0.25.1"
 pyyaml = "^6.0.1"
 redis = "4.6.0"
-requests = "^2.32.4"
 websocket-client = "^1.8.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Up until now, it was possible to add and remove streams through a call to the streamproxy api. This means that it is possible to control streams without passing through the GRPC server of Argus. To limit the area of possible attacks, this PR removes these API calls and makes the changes only possible through commands being sent to a multiprocessing queue between the spawner and stream service.

In addition, I added a close all streams function to the streamer, which is called when the server receives a termination signal. This call effectively closes all websocket connections of the streamsproxy