### PR TITLE
allow configuration path setting

### DIFF
--- a/argussight/core/config.py
+++ b/argussight/core/config.py
@@ -12,6 +12,7 @@ class RedisConfiguration(BaseModel):
 
 
 class CollectorConfiguration(BaseModel):
+    config_path: str
     redis: RedisConfiguration
 
 

--- a/argussight/core/spawner.py
+++ b/argussight/core/spawner.py
@@ -11,6 +11,7 @@ import psutil
 import yaml
 
 import argussight.streamsproxy as StreamsProxy
+from argussight.core.config import CollectorConfiguration
 from argussight.core.helper_functions import find_close_key, find_free_port
 from argussight.core.manager import Manager
 from argussight.core.video_processes.streamer.streamer import Streamer
@@ -19,7 +20,7 @@ from argussight.logger import configure_logger
 
 
 class Spawner:
-    def __init__(self, collector_config) -> None:
+    def __init__(self, collector_config: CollectorConfiguration) -> None:
         self._processes = {}
         self._worker_classes = {}
         self._managers_dict = {}
@@ -30,8 +31,7 @@ class Spawner:
         self._streams = set([])
         self._logger = configure_logger("Spawner", "Spawner")
 
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        self.load_config(os.path.join(current_dir, "configurations/config.yaml"))
+        self.load_config(os.path.join(collector_config.config_path, "config.yaml"))
 
         self._starts_stream_proxy()
 

--- a/argussight/core/video_processes/vprocess.py
+++ b/argussight/core/video_processes/vprocess.py
@@ -17,10 +17,7 @@ import redis
 import yaml
 from PIL import Image
 
-CONFIG_BASE_PATH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "../configurations/processes"
-)
-CONFIGS_EXTENSION = ".yaml"
+from argussight.core.config import CollectorConfiguration
 
 
 class ProcessError(Exception):
@@ -37,7 +34,10 @@ class FrameFormat(Enum):
 
 class Vprocess:
     def __init__(
-        self, collector_config, exposed_parameters: Dict[str, Any], logger: Logger
+        self,
+        collector_config: CollectorConfiguration,
+        exposed_parameters: Dict[str, Any],
+        logger: Logger,
     ) -> None:
         self._current_frame_number = -1
         self._current_frame = None
@@ -63,7 +63,7 @@ class Vprocess:
             host=collector_config.redis.host, port=collector_config.redis.port
         )
         self._channel = collector_config.redis.channel
-        self._config = self.load_config_from_file()
+        self._config = self.load_config_from_file(collector_config.config_path)
         self.exposed_parameters = exposed_parameters
         self._parameters = self._get_all_parameters()
 
@@ -72,13 +72,13 @@ class Vprocess:
         merged["parameters"].update(new_dict["parameters"])
         return merged
 
-    def load_config_from_file(self) -> Dict:
+    def load_config_from_file(self, base_config_path: str) -> Dict:
         class_hierarchy = self.__class__.mro()[:-1]
         final_config = {"parameters": {}}
         for klass in reversed(class_hierarchy):
             file_name = os.path.splitext(self.get_class_file(klass))[0]
             config_path = self.__class__.find_config_file(
-                CONFIG_BASE_PATH, file_name + CONFIGS_EXTENSION
+                os.path.join(base_config_path, "processes"), file_name + ".yaml"
             )
 
             if not config_path:

--- a/argussight/grpc/server.py
+++ b/argussight/grpc/server.py
@@ -8,6 +8,7 @@ import grpc
 
 import argussight.grpc.argus_service_pb2 as pb2
 import argussight.grpc.argus_service_pb2_grpc as pb2_grpc
+from argussight.core.config import CollectorConfiguration
 from argussight.core.spawner import ProcessError, Spawner
 from argussight.grpc.helper_functions import pack_to_any, unpack_from_any
 
@@ -285,7 +286,7 @@ class SpawnerService(pb2_grpc.SpawnerServiceServicer):
             )
 
 
-def serve(collector_config):
+def serve(collector_config: CollectorConfiguration):
     """
     Starts the gRPC server and listens for incoming requests.
 

--- a/argussight/main.py
+++ b/argussight/main.py
@@ -47,11 +47,12 @@ def run() -> None:
 
     config = get_config_from_dict(
         {
+            "config_path": args.config_file_path,
             "redis": {
                 "host": args.host,
                 "port": args.port,
                 "channel": args.channel,
-            }
+            },
         }
     )
 


### PR DESCRIPTION
There was the possibility to set the configuration files for argussight in the command line, but this path was never correctly propagated. This PR fixes this problem